### PR TITLE
Add Copilot instructions for description generation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# Copilot Instructions
+
+## Repository Content
+This repository contains Power BI reports in PBIP (Power BI Project) format, located in the src folder. The repository is structured to include report definitions and semantic model defintions.
+
+## Guidelines for Copilot
+
+### File-Specific Instructions
+- For '.tmdl' files:
+    - Ensure that descriptions for measures and columns are generated accurately and placed in the correct locations within the '.tmdl' file structure.
+    - Maintain the integrity of the '.tmdl' file by preserving all existing properties and syntax.
+    - Avoid overwriting or removing any properties while inserting descriptions.
+    - Validate the '.tmdl' file structure after generating descriptions to ensure it remains valid.
+    - Use concise and meaningful descriptions that align with the purpose of the measure or column.
+    - The format should be '/// Descriptions' here placed right above each 'table, 'column', or 'measure' identifier in the TMDL code.
+    - Ensure comments provide clear explanations of the defintions and purpose of the table, column or measure, incorporating COMPANY X's business and data practices
+- For '.dax' files: Provide explanations and optimization for DAX queries.
+
+### Restrictions
+- Keep in mind that existing descriptions are likely to be correct and validate but could potentially use improvements.
+
+### Context for description generation
+- This repository contains Power BI reports for COMPANY X
+- COMPANY X sells ...


### PR DESCRIPTION
Providing a sample copilot-instructions.md file as mentioned under your LinkedIn post last week regarding this repo.

The instructions are focused on explaining Github Copilot:
- Where to add descriptions for tables, columns and measures within a TMDL file.
- To utilize the object name and expression
- To be cautious with existing descriptions and existing set properties.

Please see below the differences between not having the instructions file and including it in the repo with the same prompt and TMDL file. _'Generate descriptions for measures and columns in this tmdl file'_

**Without copilot-instructions.md**
![image](https://github.com/user-attachments/assets/6cf6cab3-2655-4145-b687-57fb143abee9)


**With copilot-instructions.md**
![image](https://github.com/user-attachments/assets/061d34b1-dc9c-4109-8a63-8126f71a36b1)
